### PR TITLE
Fix six correctness and safety bugs identified during codebase review

### DIFF
--- a/src/ProcrastiN8/Common/OpenAIExcuseProvider.cs
+++ b/src/ProcrastiN8/Common/OpenAIExcuseProvider.cs
@@ -52,12 +52,19 @@ public class OpenAIExcuseProvider(string apiKey, HttpClient httpClient) : IExcus
         try
         {
             var jsonResponse = JsonSerializer.Deserialize<JsonElement>(responseContent);
-            if (jsonResponse.TryGetProperty("choices", out var choices) &&
-                choices.GetArrayLength() > 0 &&
-                choices[0].TryGetProperty("message", out var message) &&
-                message.TryGetProperty("content", out var content))
+            if (jsonResponse.ValueKind == JsonValueKind.Object &&
+                jsonResponse.TryGetProperty("choices", out var choices) &&
+                choices.ValueKind == JsonValueKind.Array &&
+                choices.GetArrayLength() > 0)
             {
-                return content.GetString() ?? "No excuse available.";
+                var firstChoice = choices[0];
+                if (firstChoice.ValueKind == JsonValueKind.Object &&
+                    firstChoice.TryGetProperty("message", out var message) &&
+                    message.ValueKind == JsonValueKind.Object &&
+                    message.TryGetProperty("content", out var content))
+                {
+                    return content.GetString() ?? "No excuse available.";
+                }
             }
         }
         catch (JsonException) { }

--- a/src/ProcrastiN8/Common/OpenAIExcuseProvider.cs
+++ b/src/ProcrastiN8/Common/OpenAIExcuseProvider.cs
@@ -49,7 +49,18 @@ public class OpenAIExcuseProvider(string apiKey, HttpClient httpClient) : IExcus
         response.EnsureSuccessStatusCode();
 
         var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-        var jsonResponse = JsonSerializer.Deserialize<JsonElement>(responseContent);
-        return jsonResponse.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? "No excuse available.";
+        try
+        {
+            var jsonResponse = JsonSerializer.Deserialize<JsonElement>(responseContent);
+            if (jsonResponse.TryGetProperty("choices", out var choices) &&
+                choices.GetArrayLength() > 0 &&
+                choices[0].TryGetProperty("message", out var message) &&
+                message.TryGetProperty("content", out var content))
+            {
+                return content.GetString() ?? "No excuse available.";
+            }
+        }
+        catch (JsonException) { }
+        return "No excuse available.";
     }
 }

--- a/src/ProcrastiN8/JustBecause/CollapseBehaviors/CopenhagenCollapseBehavior.cs
+++ b/src/ProcrastiN8/JustBecause/CollapseBehaviors/CopenhagenCollapseBehavior.cs
@@ -43,7 +43,9 @@ public sealed class CopenhagenCollapseBehavior<T>(IObserverContext? context = nu
                 }
                 else
                 {
-                    try { await p.ObserveAsync(cancellationToken); } catch { /* Suppress exceptions for quantum harmony */ }
+                    try { await p.ObserveAsync(cancellationToken); }
+                    catch (OperationCanceledException) { throw; }
+                    catch { /* Suppress non-cancellation exceptions for quantum harmony */ }
                 }
             });
         await Task.WhenAll(collapseTasks);

--- a/src/ProcrastiN8/JustBecause/QuantumPromise.cs
+++ b/src/ProcrastiN8/JustBecause/QuantumPromise.cs
@@ -21,8 +21,8 @@ public sealed class QuantumPromise<T>(Func<Task<T>> lazyInitializer, TimeSpan sc
     private static readonly ActivitySource ActivitySource = new("ProcrastiN8.JustBecause.QuantumPromise");
 
     private readonly Lazy<Task<T>> _lazyInitializer = new Lazy<Task<T>>(lazyInitializer) ?? throw new ArgumentNullException(nameof(lazyInitializer));
-    private readonly ITimeProvider _timeProvider = timeProvider ?? new SystemTimeProvider();
-    private readonly DateTimeOffset _creationTime = (timeProvider ?? new SystemTimeProvider()).GetUtcNow();
+    private readonly ITimeProvider _timeProvider = timeProvider ?? SystemTimeProvider.Default;
+    private readonly DateTimeOffset _creationTime = (timeProvider ?? SystemTimeProvider.Default).GetUtcNow();
     private readonly IDelayStrategy _delayStrategy = delayStrategy ?? new DefaultDelayStrategy();
     private readonly IRandomProvider _randomProvider = randomProvider ?? RandomProvider.Default;
 

--- a/src/ProcrastiN8/JustBecause/RandomProvider.cs
+++ b/src/ProcrastiN8/JustBecause/RandomProvider.cs
@@ -5,14 +5,13 @@ namespace ProcrastiN8.JustBecause;
 /// </summary>
 /// <remarks>
 /// This provider ensures testability and consistency in randomness across ProcrastiN8 components.
+/// Uses <see cref="Random.Shared"/>, which is thread-safe for concurrent access.
 /// </remarks>
 public class RandomProvider : IRandomProvider
 {
-    private readonly Random _random = new();
-
     public static readonly IRandomProvider Default = new RandomProvider();
 
     private RandomProvider() { }
 
-    public double GetDouble() => _random.NextDouble();
+    public double GetDouble() => Random.Shared.NextDouble();
 }

--- a/src/ProcrastiN8/JustBecause/RetryInSuperposition.cs
+++ b/src/ProcrastiN8/JustBecause/RetryInSuperposition.cs
@@ -84,7 +84,9 @@ public static class RetryInSuperposition
                             logger?.Debug("[RetryInSuperposition] Discarded timeline faulted: {Exception}", discarded.Exception?.Message);
                         }
                     },
-                    TaskContinuationOptions.ExecuteSynchronously)));
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default)));
 
                 return await completed;
             }

--- a/src/ProcrastiN8/JustBecause/RetryInSuperposition.cs
+++ b/src/ProcrastiN8/JustBecause/RetryInSuperposition.cs
@@ -76,7 +76,15 @@ public static class RetryInSuperposition
 
                 // Cancel surviving timelines and observe them to avoid unhandled task exceptions.
                 collapseSource.Cancel();
-                await Task.WhenAll(tasks.Select(t => t.ContinueWith(_ => { }, TaskContinuationOptions.None)));
+                await Task.WhenAll(tasks.Select(t => t.ContinueWith(
+                    discarded =>
+                    {
+                        if (discarded.IsFaulted)
+                        {
+                            logger?.Debug("[RetryInSuperposition] Discarded timeline faulted: {Exception}", discarded.Exception?.Message);
+                        }
+                    },
+                    TaskContinuationOptions.ExecuteSynchronously)));
 
                 return await completed;
             }

--- a/src/ProcrastiN8/Services/ProcrastinationHandle.cs
+++ b/src/ProcrastiN8/Services/ProcrastinationHandle.cs
@@ -60,6 +60,14 @@ public sealed class ProcrastinationHandle : IProcrastinationExecutionControl
         }
     }
 
+    internal void Fault(Exception exception)
+    {
+        if (!_tcs.Task.IsCompleted)
+        {
+            _tcs.TrySetException(exception);
+        }
+    }
+
     bool IProcrastinationExecutionControl.TriggerNowRequested => _triggerNow == 1;
     bool IProcrastinationExecutionControl.AbandonRequested => _abandon == 1;
 

--- a/src/ProcrastiN8/Services/ProcrastinationScheduler.cs
+++ b/src/ProcrastiN8/Services/ProcrastinationScheduler.cs
@@ -145,9 +145,9 @@ public static class ProcrastinationScheduler
             {
                 handle.Complete(new ProcrastinationResult { Mode = mode, Executed = false });
             }
-            catch
+            catch (Exception ex)
             {
-                handle.Cancel();
+                handle.Fault(ex);
             }
         }, CancellationToken.None);
 

--- a/test/ProcrastiN8.Tests/Services/ProcrastinationHandleTests.cs
+++ b/test/ProcrastiN8.Tests/Services/ProcrastinationHandleTests.cs
@@ -1,3 +1,5 @@
+using ProcrastiN8.JustBecause;
+using ProcrastiN8.LazyTasks;
 using ProcrastiN8.Services;
 
 namespace ProcrastiN8.Tests.Services;
@@ -75,5 +77,30 @@ public class ProcrastinationHandleTests
         executed.Should().BeTrue();
         result.Executed.Should().BeTrue();
         result.Triggered.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ScheduleWithHandle_TaskThrows_FaultsCompletion_WithThatException()
+    {
+        // arrange — a task so catastrophically unproductive it throws immediately
+        var expectedException = new InvalidOperationException("The task has achieved peak procrastination by refusing to run at all.");
+        var handle = ProcrastinationScheduler.ScheduleWithHandle(
+            () => throw expectedException,
+            TimeSpan.Zero,
+            ProcrastinationMode.MovingTarget,
+            delayStrategy: Substitute.For<IDelayStrategy>(),
+            randomProvider: Substitute.For<IRandomProvider>());
+
+        // act — observe the wreckage
+        var completionTask = handle.Completion;
+        var act = async () => await completionTask;
+
+        // assert — the exception surfaces rather than being silently swallowed
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "unexpected exceptions from scheduled tasks must be propagated, not buried");
+        completionTask.IsFaulted.Should().BeTrue("the handle's Completion task must be in a faulted state");
+        completionTask.Exception!.InnerExceptions.Should().ContainSingle(
+            ex => ex == expectedException,
+            "the exact exception thrown by the task must be visible to awaiting callers");
     }
 }


### PR DESCRIPTION
- RandomProvider: replace non-thread-safe `new Random()` with `Random.Shared`
  so concurrent callers can't corrupt internal PRNG state
- QuantumPromise: use `SystemTimeProvider.Default` singleton instead of creating
  two separate `SystemTimeProvider` instances (one was immediately discarded)
- OpenAIExcuseProvider: replace bare `GetProperty()`/index access (throws on any
  unexpected response shape) with `TryGetProperty` + bounds check + `JsonException`
  guard so malformed OpenAI responses degrade gracefully
- CopenhagenCollapseBehavior: bare `catch {}` was swallowing
  `OperationCanceledException`, breaking cooperative cancellation; re-throw it
- ProcrastinationHandle: add `Fault(Exception)` so the background fire-and-forget
  in ScheduleWithHandle can surface unexpected exceptions to awaiting callers
  instead of silently calling `Cancel()`
- RetryInSuperposition: use `ExecuteSynchronously` on discard continuations to
  avoid redundant thread-pool hops, and log faulted discarded timelines

https://claude.ai/code/session_012K7devzfWFbzEHkTTseGu2